### PR TITLE
Fix typo in action trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release
 on:
   push:
-    branches:
-      - master
+    branches: [ main ]
 jobs:
   release:
     name: Release


### PR DESCRIPTION
In order to make sure the release action is triggered on pushes to `main`